### PR TITLE
[feature] Student: add student counseling history endpoint with pagination

### DIFF
--- a/bin/swagger-output.json
+++ b/bin/swagger-output.json
@@ -754,6 +754,45 @@
             "bearerAuth": []
           }
         ]
+      },
+      "get": {
+        "tags": [
+          "Konseling"
+        ],
+        "summary": "Tampilkan riwayat konseling siswa",
+        "description": "Endpoint untuk siswa melihat riwayat pengajuan konseling miliknya sendiri.",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "description": "Nomor halaman (default: 1)"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "description": "Jumlah data per halaman (default: 5)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/konseling/guru/{id_guru_bk}": {

--- a/docs/swagger-output.json
+++ b/docs/swagger-output.json
@@ -754,6 +754,45 @@
             "bearerAuth": []
           }
         ]
+      },
+      "get": {
+        "tags": [
+          "Konseling"
+        ],
+        "summary": "Tampilkan riwayat konseling siswa",
+        "description": "Endpoint untuk siswa melihat riwayat pengajuan konseling miliknya sendiri.",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "description": "Nomor halaman (default: 1)"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "description": "Jumlah data per halaman (default: 5)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/konseling/guru/{id_guru_bk}": {

--- a/routes/konselingRouter.js
+++ b/routes/konselingRouter.js
@@ -45,6 +45,31 @@ router.post(
 );
 
 router.get(
+  "/",
+  verifyToken,
+  verifyRole("siswa"),
+  /*
+  #swagger.tags = ['Konseling']
+  #swagger.summary = 'Tampilkan riwayat konseling siswa'
+  #swagger.description = 'Endpoint untuk siswa melihat riwayat pengajuan konseling miliknya sendiri.'
+  #swagger.security = [{ "bearerAuth": [] }]
+  #swagger.parameters['page'] = {
+      in: 'query',
+      required: false,
+      type: 'integer',
+      description: 'Nomor halaman (default: 1)'
+  }
+  #swagger.parameters['limit'] = {
+      in: 'query',
+      required: false,
+      type: 'integer',
+      description: 'Jumlah data per halaman (default: 5)'
+  }
+  */
+  konselingController.getRiwayatKonseling
+);
+
+router.get(
   "/guru/:id_guru_bk",
   verifyToken,
   verifyRole("guru_bk"),


### PR DESCRIPTION
- Add new GET /konseling endpoint for students to view their counseling history. 
- The endpoint includes pagination support (page/limit parameters) and returns formatted data with counselor details and relationship information. 
- Updated Swagger documentation and route definitions to support the new functionality.